### PR TITLE
Exit when outdated version of node is used

### DIFF
--- a/packages/cli/bin/wcfactory-cli.js
+++ b/packages/cli/bin/wcfactory-cli.js
@@ -14,9 +14,9 @@ var pkg = require('../package.json');
 // Exit early if the user's node version is too low.
 require('please-upgrade-node')(pkg);
 
-const program = require('commander')
-const yeoman = require('yeoman-environment')
-const env = yeoman.createEnv()
+var program = require('commander')
+var yeoman = require('yeoman-environment')
+var env = yeoman.createEnv()
 
 
 /**
@@ -36,15 +36,15 @@ program
 program
   .command('new')
   .description('Create a new element.')
-  .action((name) => {
-    env.run(`wcfactory:app`)
+  .action(function (name) {
+    env.run('wcfactory:app')
   })
 
 program
   .command('init')
   .description('Create mono repo for your element library. You will only need to do this once.')
-  .action((name) => {
-    env.run(`wcfactory:init`)
+  .action(function (name) {
+    env.run('wcfactory:init')
   })
 
 // instantiate commander

--- a/packages/cli/bin/wcfactory-cli.js
+++ b/packages/cli/bin/wcfactory-cli.js
@@ -9,27 +9,15 @@
  * asynchronously after this version check has been performed.
  */
 
-// NOTE 04-21-2017: Confirmed "semver" supports Node versions as low as 0.10
-var semver = require('semver');
-var version = require('../package.json').engines.node;
-var wcfactoryVersion = require('../package.json').version;
-var description = require('../package.json').description;
-const { exec, spawn } = require('child_process')
-const program = require('commander')
-const yeoman = require('yeoman-environment')
-const shell = require('shelljs')
-const env = yeoman.createEnv()
+var pkg = require('../package.json');
 
 // Exit early if the user's node version is too low.
-if (!semver.satisfies(process.version, version)) {
-  // Strip version range characters leaving the raw semantic version for output
-  var rawVersion = version.replace(/[^\d\.]*/, '');
-  console.log(
-      'WCFactory requires at least Node v' + rawVersion + '. ' +
-      'You have ' + process.version + '.\n'
-  )
-  process.exit(1);
-}
+require('please-upgrade-node')(pkg);
+
+const program = require('commander')
+const yeoman = require('yeoman-environment')
+const env = yeoman.createEnv()
+
 
 /**
  * Register our yeoman generators
@@ -42,8 +30,8 @@ env.register(require.resolve('@wcfactory/generator-wcfactory/generators/init'), 
  * yeoman generator.
  */
 program
-  .version(wcfactoryVersion)
-  .description(description)
+  .version(pkg.version)
+  .description(pkg.description)
 
 program
   .command('new')

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -18,22 +18,6 @@
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz",
 			"integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw=="
 		},
-		"CSSselect": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
-			"integrity": "sha1-5AVMZ7RnRl88lQDA2gqnh4xLq9I=",
-			"requires": {
-				"CSSwhat": "0.4",
-				"boolbase": "~1.0.0",
-				"domutils": "1.4",
-				"nth-check": "~1.0.0"
-			}
-		},
-		"CSSwhat": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
-			"integrity": "sha1-hn2g/zn3eGEyQsRM/qg/CqTr35s="
-		},
 		"ansi-escapes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -45,9 +29,12 @@
 			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
 		},
 		"ansi-styles": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
-			"integrity": "sha1-NZq0sV3NZLptdHNLcsNjYKmvLBk="
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
 		},
 		"arr-diff": {
 			"version": "4.0.0",
@@ -87,35 +74,15 @@
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
 		},
-		"asn1": {
-			"version": "0.1.11",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
-			"integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
-		},
-		"assert-plus": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
-			"integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
-		},
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
 		},
-		"async": {
-			"version": "0.2.10",
-			"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-			"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-		},
-		"aws-sign": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz",
-			"integrity": "sha1-PYHKabR0seFlGHKLUcJP8Lvtxuk="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -170,27 +137,6 @@
 						"kind-of": "^6.0.2"
 					}
 				}
-			}
-		},
-		"block-stream": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-			"requires": {
-				"inherits": "~2.0.0"
-			}
-		},
-		"boolbase": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
-		},
-		"boom": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-			"integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-			"requires": {
-				"hoek": "0.9.x"
 			}
 		},
 		"brace-expansion": {
@@ -251,37 +197,19 @@
 			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
 		},
 		"chalk": {
-			"version": "0.2.1",
-			"resolved": "http://registry.npmjs.org/chalk/-/chalk-0.2.1.tgz",
-			"integrity": "sha1-dhPhV1FFshOGSD9/SFql/6jL0Qw=",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "~0.2.0",
-				"has-color": "~0.1.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-		},
-		"cheerio": {
-			"version": "0.12.4",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
-			"integrity": "sha1-wZlibp4esNQjOpGkeT5/iqppoYs=",
-			"requires": {
-				"cheerio-select": "*",
-				"entities": "0.x",
-				"htmlparser2": "3.1.4",
-				"underscore": "~1.4"
-			}
-		},
-		"cheerio-select": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
-			"integrity": "sha1-PyQgEU88ywsbB1wkXM+q5dYXo4g=",
-			"requires": {
-				"CSSselect": "0.x"
-			}
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -302,15 +230,6 @@
 						"is-descriptor": "^0.1.0"
 					}
 				}
-			}
-		},
-		"cli-color": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-			"integrity": "sha1-CiXOrlpqFgK+f3fShWPDZwAnTog=",
-			"requires": {
-				"es5-ext": "~0.9.2",
-				"memoizee": "~0.2.5"
 			}
 		},
 		"cli-cursor": {
@@ -358,14 +277,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"combined-stream": {
-			"version": "0.0.7",
-			"resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
-			"integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
-			"requires": {
-				"delayed-stream": "0.0.5"
-			}
-		},
 		"commander": {
 			"version": "2.18.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
@@ -380,11 +291,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"cookie-jar": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz",
-			"integrity": "sha1-vJon1OK5fhhs1XyeIGPLmfpozMw="
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -408,28 +314,13 @@
 				"which": "^1.2.9"
 			}
 		},
-		"cryptiles": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-			"integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-			"requires": {
-				"boom": "0.4.x"
-			}
-		},
-		"ctype": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
-			"integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
-		},
-		"dargs": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/dargs/-/dargs-0.1.0.tgz",
-			"integrity": "sha1-I2Stn0Qfl23NX+mWHiFxVmWl48M="
-		},
 		"debug": {
-			"version": "0.7.4",
-			"resolved": "http://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
-			"integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+			"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
 		},
 		"decode-uri-component": {
 			"version": "0.2.0",
@@ -473,15 +364,10 @@
 				}
 			}
 		},
-		"delayed-stream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
-			"integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
-		},
 		"diff": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
-			"integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY="
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"dir-glob": {
 			"version": "2.0.0",
@@ -492,49 +378,10 @@
 				"path-type": "^3.0.0"
 			}
 		},
-		"domelementtype": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
-		},
-		"domhandler": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz",
-			"integrity": "sha1-iJ+N9iZAOvB4jinWbV1cb36/D9Y=",
-			"requires": {
-				"domelementtype": "1"
-			}
-		},
-		"domutils": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
-			"integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
-			"requires": {
-				"domelementtype": "1"
-			}
-		},
-		"entities": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
-			"integrity": "sha1-9hHLWuIhBQ4AEsZpeVA/164ZzEk="
-		},
-		"es5-ext": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
-			"integrity": "sha1-0uMJ0fIjsHGGSINaz1uII6gGH4o="
-		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
-		"event-emitter": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
-			"integrity": "sha1-yB43JOtVQHxaDV7jKZQR9wD1QpE=",
-			"requires": {
-				"es5-ext": "~0.9.2"
-			}
 		},
 		"expand-brackets": {
 			"version": "2.1.4",
@@ -608,16 +455,6 @@
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
 				"tmp": "^0.0.33"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				}
 			}
 		},
 		"extglob": {
@@ -721,85 +558,18 @@
 				}
 			}
 		},
-		"findup-sync": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
-			"integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
-			"requires": {
-				"glob": "~3.2.9",
-				"lodash": "~2.4.1"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "2.4.2",
-					"resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-				}
-			}
-		},
 		"first-chunk-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
 			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
 			"requires": {
 				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-		},
-		"forever-agent": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
-			"integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
-		},
-		"form-data": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
-			"integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
-			"requires": {
-				"async": "~0.9.0",
-				"combined-stream": "~0.0.4",
-				"mime": "~1.2.11"
-			},
-			"dependencies": {
-				"async": {
-					"version": "0.9.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-				}
-			}
 		},
 		"fragment-cache": {
 			"version": "0.2.1",
@@ -814,47 +584,22 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
-		"fstream": {
-			"version": "0.1.31",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
-			"integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
-			"requires": {
-				"graceful-fs": "~3.0.2",
-				"inherits": "~2.0.0",
-				"mkdirp": "0.5",
-				"rimraf": "2"
-			},
-			"dependencies": {
-				"mkdirp": {
-					"version": "0.5.1",
-					"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				}
-			}
-		},
-		"generator-vue": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/generator-vue/-/generator-vue-0.0.2.tgz",
-			"integrity": "sha1-1wzA3ehpufpoqja+sqRvX9Ip6SI=",
-			"requires": {
-				"yeoman-generator": "~0.13.0"
-			}
-		},
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"glob": {
-			"version": "3.2.11",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-			"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "0.3"
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-parent": {
@@ -893,38 +638,12 @@
 				"ignore": "^3.3.5",
 				"pify": "^3.0.0",
 				"slash": "^1.0.0"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				}
 			}
 		},
 		"graceful-fs": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-			"integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-			"requires": {
-				"natives": "^1.1.0"
-			}
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"grouped-queue": {
 			"version": "0.3.3",
@@ -932,19 +651,7 @@
 			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
 			"requires": {
 				"lodash": "^4.17.2"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-				}
 			}
-		},
-		"has-color": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
 		},
 		"has-flag": {
 			"version": "3.0.0",
@@ -980,57 +687,13 @@
 				}
 			}
 		},
-		"hawk": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
-			"integrity": "sha1-uQuxaYByhUEdp//LjdJZhQLTtS0=",
-			"requires": {
-				"boom": "0.4.x",
-				"cryptiles": "0.2.x",
-				"hoek": "0.9.x",
-				"sntp": "0.2.x"
-			}
-		},
-		"hoek": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-			"integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
-		},
-		"htmlparser2": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
-			"integrity": "sha1-csvn1dVsAaz2H897kzMx9ORbNvA=",
-			"requires": {
-				"domelementtype": "1",
-				"domhandler": "2.0",
-				"domutils": "1.1",
-				"readable-stream": "1.0"
-			},
-			"dependencies": {
-				"domutils": {
-					"version": "1.1.6",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
-					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-					"requires": {
-						"domelementtype": "1"
-					}
-				}
-			}
-		},
-		"http-signature": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
-			"integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
-			"requires": {
-				"asn1": "0.1.11",
-				"assert-plus": "^0.1.5",
-				"ctype": "0.5.3"
-			}
-		},
 		"iconv-lite": {
-			"version": "0.2.11",
-			"resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-			"integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
 		},
 		"ignore": {
 			"version": "3.3.10",
@@ -1052,27 +715,24 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"inquirer": {
-			"version": "0.3.5",
-			"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.3.5.tgz",
-			"integrity": "sha1-p4vgZKyavxaBR8Ahaakx2aSDqfY=",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+			"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
 			"requires": {
-				"async": "~0.2.8",
-				"cli-color": "~0.2.2",
-				"lodash": "~1.2.1",
-				"mute-stream": "0.0.3"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "1.2.1",
-					"resolved": "http://registry.npmjs.org/lodash/-/lodash-1.2.1.tgz",
-					"integrity": "sha1-7UexbkbwaytAMJto6RY8F+k+owQ="
-				}
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.0",
+				"cli-cursor": "^2.1.0",
+				"cli-width": "^2.0.0",
+				"external-editor": "^3.0.0",
+				"figures": "^2.0.0",
+				"lodash": "^4.17.10",
+				"mute-stream": "0.0.7",
+				"run-async": "^2.2.0",
+				"rxjs": "^6.1.0",
+				"string-width": "^2.1.0",
+				"strip-ansi": "^4.0.0",
+				"through": "^2.3.6"
 			}
-		},
-		"interpret": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -1205,14 +865,9 @@
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-		},
-		"isbinaryfile": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-0.1.9.tgz",
-			"integrity": "sha1-Fe7ONcSrcI2JJNqZ+4dPK1zAtsQ="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1224,20 +879,15 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
 		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-		},
 		"kind-of": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
 			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 		},
 		"lodash": {
-			"version": "1.3.1",
-			"resolved": "http://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
-			"integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -1245,32 +895,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"requires": {
 				"chalk": "^2.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				}
 			}
-		},
-		"lru-cache": {
-			"version": "2.7.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-			"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
 		},
 		"map-cache": {
 			"version": "0.2.2",
@@ -1293,16 +918,6 @@
 				"through2": "^2.0.0",
 				"vinyl": "^1.1.0",
 				"vinyl-file": "^2.0.0"
-			}
-		},
-		"memoizee": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-			"integrity": "sha1-u0WnrQJTAILxYSZx2rNSGc0uB0E=",
-			"requires": {
-				"es5-ext": "~0.9.2",
-				"event-emitter": "~0.2.2",
-				"next-tick": "0.1.x"
 			}
 		},
 		"merge2": {
@@ -1330,29 +945,18 @@
 				"to-regex": "^3.0.2"
 			}
 		},
-		"mime": {
-			"version": "1.2.11",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-			"integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
-		},
 		"mimic-fn": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
 			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
 		},
 		"minimatch": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-			"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"lru-cache": "2",
-				"sigmund": "~1.0.0"
+				"brace-expansion": "^1.1.7"
 			}
-		},
-		"minimist": {
-			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"mixin-deep": {
 			"version": "1.3.1",
@@ -1373,20 +977,15 @@
 				}
 			}
 		},
-		"mkdirp": {
-			"version": "0.3.5",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-			"integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
-		},
 		"ms": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 		},
 		"mute-stream": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.3.tgz",
-			"integrity": "sha1-8JwJDTM7MGP2Fcu8ynGzSYk/AVI="
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -1406,38 +1005,10 @@
 				"to-regex": "^3.0.1"
 			}
 		},
-		"natives": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.5.tgz",
-			"integrity": "sha512-1pJ+02gl2KJgCPFtpZGtuD4lGSJnIZvvFHCQTOeDRMSXjfu2GmYWuhI8NFMA4W2I5NNFRbfy/YCiVt4CgNpP8A=="
-		},
-		"next-tick": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
-			"integrity": "sha1-GRLM6OubaX1kD7upT48A3sO5Qlk="
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-		},
-		"node-uuid": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
-			"integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
-		},
-		"nth-check": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-			"requires": {
-				"boolbase": "~1.0.0"
-			}
-		},
-		"oauth-sign": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
-			"integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -1524,11 +1095,6 @@
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
 		"path-type": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
@@ -1555,6 +1121,14 @@
 				"pinkie": "^2.0.0"
 			}
 		},
+		"please-upgrade-node": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
+			"integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
+			"requires": {
+				"semver-compare": "^1.0.0"
+			}
+		},
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -1565,28 +1139,18 @@
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
-		"qs": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
-			"integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
-		},
 		"readable-stream": {
-			"version": "1.0.34",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-			"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+			"version": "2.3.6",
+			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
 				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.1",
-				"isarray": "0.0.1",
-				"string_decoder": "~0.10.x"
-			}
-		},
-		"rechoir": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"requires": {
-				"resolve": "^1.1.6"
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"regex-not": {
@@ -1613,33 +1177,6 @@
 			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
 			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
 		},
-		"request": {
-			"version": "2.25.0",
-			"resolved": "http://registry.npmjs.org/request/-/request-2.25.0.tgz",
-			"integrity": "sha1-2sFnMYGIf+CyzmvX4S9G1VSgLOk=",
-			"requires": {
-				"aws-sign": "~0.3.0",
-				"cookie-jar": "~0.3.0",
-				"forever-agent": "~0.5.0",
-				"form-data": "~0.1.0",
-				"hawk": "~1.0.0",
-				"http-signature": "~0.10.0",
-				"json-stringify-safe": "~5.0.0",
-				"mime": "~1.2.9",
-				"node-uuid": "~1.4.0",
-				"oauth-sign": "~0.3.0",
-				"qs": "~0.6.0",
-				"tunnel-agent": "~0.3.0"
-			}
-		},
-		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-			"requires": {
-				"path-parse": "^1.0.5"
-			}
-		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -1658,11 +1195,6 @@
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-		},
-		"rimraf": {
-			"version": "2.2.8",
-			"resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-			"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
 		},
 		"run-async": {
 			"version": "2.3.0",
@@ -1708,6 +1240,11 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
 			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
 		},
+		"semver-compare": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+		},
 		"set-value": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
@@ -1741,44 +1278,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-		},
-		"shelljs": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
-			"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
-			"requires": {
-				"glob": "^7.0.0",
-				"interpret": "^1.0.0",
-				"rechoir": "^0.6.2"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				}
-			}
-		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -1900,14 +1399,6 @@
 				}
 			}
 		},
-		"sntp": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-			"integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-			"requires": {
-				"hoek": "0.9.x"
-			}
-		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1967,9 +1458,12 @@
 			}
 		},
 		"string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			}
 		},
 		"strip-ansi": {
 			"version": "4.0.0",
@@ -2004,20 +1498,10 @@
 				"has-flag": "^3.0.0"
 			}
 		},
-		"tar": {
-			"version": "0.1.20",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
-			"integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
-			"requires": {
-				"block-stream": "*",
-				"fstream": "~0.1.28",
-				"inherits": "2"
-			}
-		},
 		"text-table": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.1.1.tgz",
-			"integrity": "sha1-mqQ0ejm2lQzSQZAmRXb2LbblLZM="
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
 		"through": {
 			"version": "2.3.8",
@@ -2031,35 +1515,6 @@
 			"requires": {
 				"readable-stream": "^2.1.5",
 				"xtend": "~4.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				}
 			}
 		},
 		"tmp": {
@@ -2112,21 +1567,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
 			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-		},
-		"tunnel-agent": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
-			"integrity": "sha1-rWgbaPUyGtKCfEz7G31d8s/pQu4="
-		},
-		"underscore": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
-		},
-		"underscore.string": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-			"integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
 		},
 		"union-value": {
 			"version": "1.0.0",
@@ -2193,11 +1633,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 				}
 			}
 		},
@@ -2244,11 +1679,6 @@
 				"vinyl": "^1.1.0"
 			},
 			"dependencies": {
-				"graceful-fs": {
-					"version": "4.1.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-				},
 				"pify": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -2294,108 +1724,6 @@
 				"strip-ansi": "^4.0.0",
 				"text-table": "^0.2.0",
 				"untildify": "^3.0.3"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"debug": {
-					"version": "3.2.5",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"diff": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
-				},
-				"inquirer": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
-					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.0",
-						"cli-cursor": "^2.1.0",
-						"cli-width": "^2.0.0",
-						"external-editor": "^3.0.0",
-						"figures": "^2.0.0",
-						"lodash": "^4.17.10",
-						"mute-stream": "0.0.7",
-						"run-async": "^2.2.0",
-						"rxjs": "^6.1.0",
-						"string-width": "^2.1.0",
-						"strip-ansi": "^4.0.0",
-						"through": "^2.3.6"
-					}
-				},
-				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-				},
-				"mute-stream": {
-					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-				},
-				"text-table": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-					"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-				}
-			}
-		},
-		"yeoman-generator": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-0.13.4.tgz",
-			"integrity": "sha1-BmeY3ZeAJtN75mV7JnKhe8T0zjQ=",
-			"requires": {
-				"async": "~0.2.8",
-				"chalk": "~0.2.0",
-				"cheerio": "~0.12.0",
-				"dargs": "~0.1.0",
-				"debug": "~0.7.2",
-				"diff": "~1.0.4",
-				"findup-sync": "~0.1.2",
-				"glob": "~3.2.0",
-				"iconv-lite": "~0.2.10",
-				"inquirer": "~0.3.1",
-				"isbinaryfile": "~0.1.8",
-				"lodash": "~1.3.0",
-				"mime": "~1.2.9",
-				"mkdirp": "~0.3.5",
-				"request": "~2.25.0",
-				"rimraf": "~2.2.0",
-				"shelljs": "~0.1.4",
-				"tar": "~0.1.17",
-				"text-table": "~0.1.1",
-				"underscore.string": "~2.3.1"
-			},
-			"dependencies": {
-				"shelljs": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz",
-					"integrity": "sha1-37vnjVbDwBaNL7eeEOzR28sH7A4="
-				}
 			}
 		}
 	}

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,0 +1,2402 @@
+{
+	"name": "@wcfactory/cli",
+	"version": "0.0.8",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@mrmlnc/readdir-enhanced": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+			"requires": {
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.2.tgz",
+			"integrity": "sha512-yprFYuno9FtNsSHVlSWd+nRlmGoAbqbeCwOryP6sC/zoCjhpArcRMYp19EvpSUSizJAlsXEwJv+wcWS9XaXdMw=="
+		},
+		"CSSselect": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
+			"integrity": "sha1-5AVMZ7RnRl88lQDA2gqnh4xLq9I=",
+			"requires": {
+				"CSSwhat": "0.4",
+				"boolbase": "~1.0.0",
+				"domutils": "1.4",
+				"nth-check": "~1.0.0"
+			}
+		},
+		"CSSwhat": {
+			"version": "0.4.7",
+			"resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz",
+			"integrity": "sha1-hn2g/zn3eGEyQsRM/qg/CqTr35s="
+		},
+		"ansi-escapes": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+		},
+		"ansi-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+		},
+		"ansi-styles": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-0.2.0.tgz",
+			"integrity": "sha1-NZq0sV3NZLptdHNLcsNjYKmvLBk="
+		},
+		"arr-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+		},
+		"array-union": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+			"requires": {
+				"array-uniq": "^1.0.1"
+			}
+		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+		},
+		"array-unique": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+		},
+		"asn1": {
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+			"integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc="
+		},
+		"assert-plus": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+			"integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
+		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"async": {
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+			"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+		},
+		"aws-sign": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz",
+			"integrity": "sha1-PYHKabR0seFlGHKLUcJP8Lvtxuk="
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"block-stream": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+			"requires": {
+				"inherits": "~2.0.0"
+			}
+		},
+		"boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+		},
+		"boom": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+			"integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+			"requires": {
+				"hoek": "0.9.x"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+			"requires": {
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			}
+		},
+		"call-me-maybe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+			"integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+		},
+		"chalk": {
+			"version": "0.2.1",
+			"resolved": "http://registry.npmjs.org/chalk/-/chalk-0.2.1.tgz",
+			"integrity": "sha1-dhPhV1FFshOGSD9/SFql/6jL0Qw=",
+			"requires": {
+				"ansi-styles": "~0.2.0",
+				"has-color": "~0.1.0"
+			}
+		},
+		"chardet": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+		},
+		"cheerio": {
+			"version": "0.12.4",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
+			"integrity": "sha1-wZlibp4esNQjOpGkeT5/iqppoYs=",
+			"requires": {
+				"cheerio-select": "*",
+				"entities": "0.x",
+				"htmlparser2": "3.1.4",
+				"underscore": "~1.4"
+			}
+		},
+		"cheerio-select": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
+			"integrity": "sha1-PyQgEU88ywsbB1wkXM+q5dYXo4g=",
+			"requires": {
+				"CSSselect": "0.x"
+			}
+		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"cli-color": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+			"integrity": "sha1-CiXOrlpqFgK+f3fShWPDZwAnTog=",
+			"requires": {
+				"es5-ext": "~0.9.2",
+				"memoizee": "~0.2.5"
+			}
+		},
+		"cli-cursor": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+			"requires": {
+				"restore-cursor": "^2.0.0"
+			}
+		},
+		"cli-width": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+		},
+		"clone": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+		},
+		"clone-stats": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+		},
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+			"requires": {
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"combined-stream": {
+			"version": "0.0.7",
+			"resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+			"integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+			"requires": {
+				"delayed-stream": "0.0.5"
+			}
+		},
+		"commander": {
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.18.0.tgz",
+			"integrity": "sha512-6CYPa+JP2ftfRU2qkDK+UTVeQYosOg/2GbcjIcKPHfinyOLPVGXu/ovN86RP49Re5ndJK1N0kuiidFFuepc4ZQ=="
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"cookie-jar": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz",
+			"integrity": "sha1-vJon1OK5fhhs1XyeIGPLmfpozMw="
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"cryptiles": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+			"integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+			"requires": {
+				"boom": "0.4.x"
+			}
+		},
+		"ctype": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+			"integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8="
+		},
+		"dargs": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dargs/-/dargs-0.1.0.tgz",
+			"integrity": "sha1-I2Stn0Qfl23NX+mWHiFxVmWl48M="
+		},
+		"debug": {
+			"version": "0.7.4",
+			"resolved": "http://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+			"integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"delayed-stream": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+			"integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8="
+		},
+		"diff": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+			"integrity": "sha1-NDJ2MI7Jkbe8giZ+1VvBQR+XFmY="
+		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"requires": {
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
+			}
+		},
+		"domelementtype": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+		},
+		"domhandler": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz",
+			"integrity": "sha1-iJ+N9iZAOvB4jinWbV1cb36/D9Y=",
+			"requires": {
+				"domelementtype": "1"
+			}
+		},
+		"domutils": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+			"integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
+			"requires": {
+				"domelementtype": "1"
+			}
+		},
+		"entities": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz",
+			"integrity": "sha1-9hHLWuIhBQ4AEsZpeVA/164ZzEk="
+		},
+		"es5-ext": {
+			"version": "0.9.2",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
+			"integrity": "sha1-0uMJ0fIjsHGGSINaz1uII6gGH4o="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"event-emitter": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
+			"integrity": "sha1-yB43JOtVQHxaDV7jKZQR9wD1QpE=",
+			"requires": {
+				"es5-ext": "~0.9.2"
+			}
+		},
+		"expand-brackets": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+			"requires": {
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"external-editor": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+			"requires": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
+			},
+			"dependencies": {
+				"iconv-lite": {
+					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				}
+			}
+		},
+		"extglob": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+			"requires": {
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"fast-glob": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.2.tgz",
+			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
+			"requires": {
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.0.1",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.1",
+				"micromatch": "^3.1.10"
+			}
+		},
+		"figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+			"requires": {
+				"escape-string-regexp": "^1.0.5"
+			}
+		},
+		"fill-range": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"findup-sync": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+			"integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
+			"requires": {
+				"glob": "~3.2.9",
+				"lodash": "~2.4.1"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "2.4.2",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+				}
+			}
+		},
+		"first-chunk-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+			"integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+			"requires": {
+				"readable-stream": "^2.0.2"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+		},
+		"forever-agent": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+			"integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA="
+		},
+		"form-data": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+			"integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
+			"requires": {
+				"async": "~0.9.0",
+				"combined-stream": "~0.0.4",
+				"mime": "~1.2.11"
+			},
+			"dependencies": {
+				"async": {
+					"version": "0.9.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+					"integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+				}
+			}
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"requires": {
+				"map-cache": "^0.2.2"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fstream": {
+			"version": "0.1.31",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+			"integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+			"requires": {
+				"graceful-fs": "~3.0.2",
+				"inherits": "~2.0.0",
+				"mkdirp": "0.5",
+				"rimraf": "2"
+			},
+			"dependencies": {
+				"mkdirp": {
+					"version": "0.5.1",
+					"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				}
+			}
+		},
+		"generator-vue": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/generator-vue/-/generator-vue-0.0.2.tgz",
+			"integrity": "sha1-1wzA3ehpufpoqja+sqRvX9Ip6SI=",
+			"requires": {
+				"yeoman-generator": "~0.13.0"
+			}
+		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+		},
+		"glob": {
+			"version": "3.2.11",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+			"integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+			"requires": {
+				"inherits": "2",
+				"minimatch": "0.3"
+			}
+		},
+		"glob-parent": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+			"requires": {
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
+			},
+			"dependencies": {
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				}
+			}
+		},
+		"glob-to-regexp": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+		},
+		"globby": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-8.0.1.tgz",
+			"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
+			"requires": {
+				"array-union": "^1.0.1",
+				"dir-glob": "^2.0.0",
+				"fast-glob": "^2.0.2",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				}
+			}
+		},
+		"graceful-fs": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+			"integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+			"requires": {
+				"natives": "^1.1.0"
+			}
+		},
+		"grouped-queue": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
+			"integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
+			"requires": {
+				"lodash": "^4.17.2"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				}
+			}
+		},
+		"has-color": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+			"integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"hawk": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+			"integrity": "sha1-uQuxaYByhUEdp//LjdJZhQLTtS0=",
+			"requires": {
+				"boom": "0.4.x",
+				"cryptiles": "0.2.x",
+				"hoek": "0.9.x",
+				"sntp": "0.2.x"
+			}
+		},
+		"hoek": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+			"integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
+		},
+		"htmlparser2": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
+			"integrity": "sha1-csvn1dVsAaz2H897kzMx9ORbNvA=",
+			"requires": {
+				"domelementtype": "1",
+				"domhandler": "2.0",
+				"domutils": "1.1",
+				"readable-stream": "1.0"
+			},
+			"dependencies": {
+				"domutils": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
+					"requires": {
+						"domelementtype": "1"
+					}
+				}
+			}
+		},
+		"http-signature": {
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+			"integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+			"requires": {
+				"asn1": "0.1.11",
+				"assert-plus": "^0.1.5",
+				"ctype": "0.5.3"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.2.11",
+			"resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+			"integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
+		},
+		"ignore": {
+			"version": "3.3.10",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"inquirer": {
+			"version": "0.3.5",
+			"resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.3.5.tgz",
+			"integrity": "sha1-p4vgZKyavxaBR8Ahaakx2aSDqfY=",
+			"requires": {
+				"async": "~0.2.8",
+				"cli-color": "~0.2.2",
+				"lodash": "~1.2.1",
+				"mute-stream": "0.0.3"
+			},
+			"dependencies": {
+				"lodash": {
+					"version": "1.2.1",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-1.2.1.tgz",
+					"integrity": "sha1-7UexbkbwaytAMJto6RY8F+k+owQ="
+				}
+			}
+		},
+		"interpret": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+				}
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+		},
+		"is-glob": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
+		"is-number": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+		},
+		"is-scoped": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
+			"integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
+			"requires": {
+				"scoped-regex": "^1.0.0"
+			}
+		},
+		"is-utf8": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
+		"isbinaryfile": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-0.1.9.tgz",
+			"integrity": "sha1-Fe7ONcSrcI2JJNqZ+4dPK1zAtsQ="
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+		},
+		"isobject": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+		},
+		"kind-of": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+		},
+		"lodash": {
+			"version": "1.3.1",
+			"resolved": "http://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+			"integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
+		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"requires": {
+				"chalk": "^2.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				}
+			}
+		},
+		"lru-cache": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+			"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"requires": {
+				"object-visit": "^1.0.0"
+			}
+		},
+		"mem-fs": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.3.tgz",
+			"integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
+			"requires": {
+				"through2": "^2.0.0",
+				"vinyl": "^1.1.0",
+				"vinyl-file": "^2.0.0"
+			}
+		},
+		"memoizee": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+			"integrity": "sha1-u0WnrQJTAILxYSZx2rNSGc0uB0E=",
+			"requires": {
+				"es5-ext": "~0.9.2",
+				"event-emitter": "~0.2.2",
+				"next-tick": "0.1.x"
+			}
+		},
+		"merge2": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.2.tgz",
+			"integrity": "sha512-bgM8twH86rWni21thii6WCMQMRMmwqqdW3sGWi9IipnVAszdLXRjwDwAnyrVXo6DuP3AjRMMttZKUB48QWIFGg=="
+		},
+		"micromatch": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
+			}
+		},
+		"mime": {
+			"version": "1.2.11",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+			"integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA="
+		},
+		"mimic-fn": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+		},
+		"minimatch": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+			"integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+			"requires": {
+				"lru-cache": "2",
+				"sigmund": "~1.0.0"
+			}
+		},
+		"minimist": {
+			"version": "0.0.8",
+			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
+		"mkdirp": {
+			"version": "0.3.5",
+			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+			"integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+		},
+		"ms": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+		},
+		"mute-stream": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.3.tgz",
+			"integrity": "sha1-8JwJDTM7MGP2Fcu8ynGzSYk/AVI="
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			}
+		},
+		"natives": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.5.tgz",
+			"integrity": "sha512-1pJ+02gl2KJgCPFtpZGtuD4lGSJnIZvvFHCQTOeDRMSXjfu2GmYWuhI8NFMA4W2I5NNFRbfy/YCiVt4CgNpP8A=="
+		},
+		"next-tick": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
+			"integrity": "sha1-GRLM6OubaX1kD7upT48A3sO5Qlk="
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+		},
+		"node-uuid": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+			"integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+		},
+		"nth-check": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+			"requires": {
+				"boolbase": "~1.0.0"
+			}
+		},
+		"oauth-sign": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+			"integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4="
+		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"requires": {
+				"isobject": "^3.0.0"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"requires": {
+				"isobject": "^3.0.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"onetime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"requires": {
+				"mimic-fn": "^1.0.0"
+			}
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
+		"path-dirname": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+		},
+		"path-type": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+			"requires": {
+				"pify": "^3.0.0"
+			}
+		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"requires": {
+				"pinkie": "^2.0.0"
+			}
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"qs": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+			"integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc="
+		},
+		"readable-stream": {
+			"version": "1.0.34",
+			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+			"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			}
+		},
+		"rechoir": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+			"requires": {
+				"resolve": "^1.1.6"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"repeat-element": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+		},
+		"replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+		},
+		"request": {
+			"version": "2.25.0",
+			"resolved": "http://registry.npmjs.org/request/-/request-2.25.0.tgz",
+			"integrity": "sha1-2sFnMYGIf+CyzmvX4S9G1VSgLOk=",
+			"requires": {
+				"aws-sign": "~0.3.0",
+				"cookie-jar": "~0.3.0",
+				"forever-agent": "~0.5.0",
+				"form-data": "~0.1.0",
+				"hawk": "~1.0.0",
+				"http-signature": "~0.10.0",
+				"json-stringify-safe": "~5.0.0",
+				"mime": "~1.2.9",
+				"node-uuid": "~1.4.0",
+				"oauth-sign": "~0.3.0",
+				"qs": "~0.6.0",
+				"tunnel-agent": "~0.3.0"
+			}
+		},
+		"resolve": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"requires": {
+				"path-parse": "^1.0.5"
+			}
+		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+		},
+		"restore-cursor": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+			"requires": {
+				"onetime": "^2.0.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+		},
+		"rimraf": {
+			"version": "2.2.8",
+			"resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+			"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
+		},
+		"run-async": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+			"requires": {
+				"is-promise": "^2.1.0"
+			}
+		},
+		"rxjs": {
+			"version": "6.3.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+			"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+			"requires": {
+				"tslib": "^1.9.0"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+		},
+		"scoped-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
+			"integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg="
+		},
+		"semver": {
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+			"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"requires": {
+				"shebang-regex": "^1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+		},
+		"shelljs": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+			"integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+			"requires": {
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				}
+			}
+		},
+		"sigmund": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"requires": {
+				"kind-of": "^3.2.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"sntp": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+			"integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+			"requires": {
+				"hoek": "0.9.x"
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
+		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+		},
+		"strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"requires": {
+				"ansi-regex": "^3.0.0"
+			}
+		},
+		"strip-bom": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+			"requires": {
+				"is-utf8": "^0.2.0"
+			}
+		},
+		"strip-bom-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+			"integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+			"requires": {
+				"first-chunk-stream": "^2.0.0",
+				"strip-bom": "^2.0.0"
+			}
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"tar": {
+			"version": "0.1.20",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+			"integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
+			"requires": {
+				"block-stream": "*",
+				"fstream": "~0.1.28",
+				"inherits": "2"
+			}
+		},
+		"text-table": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.1.1.tgz",
+			"integrity": "sha1-mqQ0ejm2lQzSQZAmRXb2LbblLZM="
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+		},
+		"through2": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+			"requires": {
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
+			}
+		},
+		"tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"requires": {
+				"os-tmpdir": "~1.0.2"
+			}
+		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"requires": {
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			}
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+		},
+		"tunnel-agent": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
+			"integrity": "sha1-rWgbaPUyGtKCfEz7G31d8s/pQu4="
+		},
+		"underscore": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+			"integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+		},
+		"underscore.string": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+			"integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0="
+		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
+			}
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+				}
+			}
+		},
+		"untildify": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+			"integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA=="
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+		},
+		"use": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"vinyl": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+			"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+			"requires": {
+				"clone": "^1.0.0",
+				"clone-stats": "^0.0.1",
+				"replace-ext": "0.0.1"
+			}
+		},
+		"vinyl-file": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-2.0.0.tgz",
+			"integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.3.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0",
+				"strip-bom-stream": "^2.0.0",
+				"vinyl": "^1.1.0"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.1.11",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+					"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+				}
+			}
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"xtend": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"yeoman-environment": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.3.3.tgz",
+			"integrity": "sha512-HBpXdNw8V66EwqIFt01rNhSgX33BOzgVb9CxpIvESvCI4ELeOSniB6gV6RXwrBur8kmHZCIAkYQYpib7Qxx8FQ==",
+			"requires": {
+				"chalk": "^2.4.1",
+				"cross-spawn": "^6.0.5",
+				"debug": "^3.1.0",
+				"diff": "^3.5.0",
+				"escape-string-regexp": "^1.0.2",
+				"globby": "^8.0.1",
+				"grouped-queue": "^0.3.3",
+				"inquirer": "^6.0.0",
+				"is-scoped": "^1.0.0",
+				"lodash": "^4.17.10",
+				"log-symbols": "^2.2.0",
+				"mem-fs": "^1.1.0",
+				"strip-ansi": "^4.0.0",
+				"text-table": "^0.2.0",
+				"untildify": "^3.0.3"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"debug": {
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"diff": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+				},
+				"inquirer": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+					"integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
+					"requires": {
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.0",
+						"cli-cursor": "^2.1.0",
+						"cli-width": "^2.0.0",
+						"external-editor": "^3.0.0",
+						"figures": "^2.0.0",
+						"lodash": "^4.17.10",
+						"mute-stream": "0.0.7",
+						"run-async": "^2.2.0",
+						"rxjs": "^6.1.0",
+						"string-width": "^2.1.0",
+						"strip-ansi": "^4.0.0",
+						"through": "^2.3.6"
+					}
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				},
+				"mute-stream": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+				},
+				"text-table": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+					"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+				}
+			}
+		},
+		"yeoman-generator": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-0.13.4.tgz",
+			"integrity": "sha1-BmeY3ZeAJtN75mV7JnKhe8T0zjQ=",
+			"requires": {
+				"async": "~0.2.8",
+				"chalk": "~0.2.0",
+				"cheerio": "~0.12.0",
+				"dargs": "~0.1.0",
+				"debug": "~0.7.2",
+				"diff": "~1.0.4",
+				"findup-sync": "~0.1.2",
+				"glob": "~3.2.0",
+				"iconv-lite": "~0.2.10",
+				"inquirer": "~0.3.1",
+				"isbinaryfile": "~0.1.8",
+				"lodash": "~1.3.0",
+				"mime": "~1.2.9",
+				"mkdirp": "~0.3.5",
+				"request": "~2.25.0",
+				"rimraf": "~2.2.0",
+				"shelljs": "~0.1.4",
+				"tar": "~0.1.17",
+				"text-table": "~0.1.1",
+				"underscore.string": "~2.3.1"
+			},
+			"dependencies": {
+				"shelljs": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.4.tgz",
+					"integrity": "sha1-37vnjVbDwBaNL7eeEOzR28sH7A4="
+				}
+			}
+		}
+	}
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,8 +14,7 @@
   "dependencies": {
     "@wcfactory/generator-wcfactory": "^0.0.8",
     "commander": "^2.18.0",
-    "generator-vue": "0.0.2",
-    "shelljs": "^0.8.2",
+    "please-upgrade-node": "^3.1.1",
     "yeoman-environment": "^2.3.3"
   },
   "bin": {

--- a/packages/generator-wcfactory/package-lock.json
+++ b/packages/generator-wcfactory/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "generator-rhelement",
-  "version": "0.6.3",
+  "name": "@wcfactory/generator-wcfactory",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -456,6 +456,23 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.0",
         "through": "^2.3.6"
+      }
+    },
+    "inquirer-recursive": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/inquirer-recursive/-/inquirer-recursive-0.0.5.tgz",
+      "integrity": "sha1-iPLCWvVC4/VdRhg4h6t51dYAiyY=",
+      "requires": {
+        "inquirer": "^1.1.2",
+        "lodash": "^3.10.1",
+        "util": "^0.10.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
       }
     },
     "interpret": {
@@ -1109,6 +1126,14 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "requires": {
         "os-homedir": "^1.0.0"
+      }
+    },
+    "util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "requires": {
+        "inherits": "2.0.3"
       }
     },
     "util-deprecate": {


### PR DESCRIPTION
Tested with Node 4 and 0.12

```
$ wcfactory
@wcfactory/cli requires at least version 6.0 of Node, please upgrade
```