### PR TITLE
fix: prevent top level package from getting accidentally published

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wcfactory",
-  "private": false,
+  "private": true,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
the top level package is only a lerna wrapper, it isn't intented to be
released to npm.

See: https://docs.npmjs.com/files/package.json#private