### PR TITLE
build: remove top level publish access

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "wcfactory",
   "private": true,
-  "publishConfig": {
-    "access": "public"
-  },
   "devDependencies": {
     "lerna": "^3.4.0"
   },


### PR DESCRIPTION
with top level package marked as private, publish access setting is no longer needed