### PR TITLE
build: use babel preset env to add polyfills where needed

### DIFF
--- a/packages/generator-wcfactory/generators/init/templates/scripts/rollup.config.factory.js
+++ b/packages/generator-wcfactory/generators/init/templates/scripts/rollup.config.factory.js
@@ -17,7 +17,12 @@ function umdConfig({ elementName, className } = {}) {
       resolve(),
       commonjs(),
       babel({
-        presets: ["@babel/env"]
+        presets: [
+          '@babel/preset-env',
+          {
+            useBuiltIns: 'usage',
+          }
+        ]
       }),
       uglify()
     ],


### PR DESCRIPTION
Not sure if this is already applied somewhere else, still learning my way around the build system.

The `"useBuiltIns": "usage"` option is how `vue-cli` and `create-react-app` inject polyfills as needed.

See: https://babeljs.io/docs/en/babel-preset-env#usebuiltins-usage-experimental