### PR TITLE
build: verify that Node LTS is used and yarn has integrity support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,9 @@
       "plugin:node/recommended",
       "plugin:prettier/recommended"
     ]
+  },
+  "engines": {
+    "node": "^6.0.0 || ^8.0.0 || ^10.0.0",
+    "yarn": "^1.10.0"
   }
 }


### PR DESCRIPTION
If expectations are not met

```
error wcfactory@: The engine "node" is incompatible with this module. Expected version "^6.0.0 || ^8.0.0 || ^10.0.0".
error wcfactory@: The engine "yarn" is incompatible with this module. Expected version "^1.10.0".
```