### PR TITLE
ci: allow failures on Windows with Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ os:
   - linux
   - osx
   - windows
+matrix:
+  allow_failures:
+    - node_js: 8
+      os: windows
 install:
   - npm install --global yarn lerna
   - lerna bootstrap


### PR DESCRIPTION
Setup is slow enough it hits the 10 minute timeout.
This prevents timeouts from failing the build, it can be removed later if Node 8 + Windows, stabilizes or speeds up.