### PR TITLE
renovate automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "automerge": true,
+  "major": {
+    "automerge": false
+  }
 }


### PR DESCRIPTION
renovate automerge patch and minor dependency updates, if and only if CI passes.
This can reduce the number of PRs that need human intervention to process them.

depends on #376 