### PR TITLE
Partial fix for #385. Also makes fixDotfiles a tiny bit more efficient.

### DIFF
--- a/packages/generator-wcfactory/utils/fix-dotfiles.js
+++ b/packages/generator-wcfactory/utils/fix-dotfiles.js
@@ -16,14 +16,20 @@ const KNOWN_DOTFILES = {
 
 exports.fixDotfiles = function(generator) {
     generator.fs.store.each(file => {
-        // Yeoman's mem-fs store includes your source directories *sigh*, so this filters those out.
-        if (!isSubPath(generator.destinationPath(), file.path)) {
+        const remap = KNOWN_DOTFILES[file.basename];
+        if (!remap) {
             return;
         }
-        const remap = KNOWN_DOTFILES[file.basename];
-        if (remap) {
-            generator.fs.move(file.path, file.dirname + '/' + remap);
+
+        // Yeoman's mem-fs store includes your source directories *sigh*, so this filters those out.
+        const isInDest = isSubPath(generator.destinationPath(), file.path);
+        // This fixes #385 - because Travis tests are being run in the same directory as our sources, we need to double-check that we're not running in the template path.
+        const isInTemplate = isSubPath(generator.templatePath(), file.path);
+        if (!isInDest || isInTemplate) {
+            return;
         }
+
+        generator.fs.move(file.path, file.dirname + '/' + remap);
     });
 }
 


### PR DESCRIPTION
Check that the dotfiles we manipulate aren't inside templatePath instead of just checking that they're in destinationPath.  This won't actually fix the travis tests, but it's still a nice safeguard to have.

Also re-arrange things in fixDotfiles to do the cheapest check first, then progress to the (slightly) more expensive ones.