### PR TITLE
updated node version and added resolutions section

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,11 @@
       "plugin:prettier/recommended"
     ]
   },
+  "resolutions": {
+    "har-validator":"5.1.3"
+  },
   "engines": {
-    "node": "^6.0.0 || ^8.0.0 || ^10.0.0 || ^11.0.0",
+    "node": "^6.0.0 || ^8.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
     "yarn": "^1.10.1"
   }
 }


### PR DESCRIPTION
added new node version and resolutions section to force the har-validator to get a valid version. It doesn't break anything but I won't be certain it fixes things until it pushes out to npmjs for deployment. Also, at some point, the resolutions section will be able to be removed when the transitive dependency is fixed