### PR TITLE
refactor: allow node to scan for bin folder

### DIFF
--- a/packages/generator-wcfactory/generators/element/templates/package.json
+++ b/packages/generator-wcfactory/generators/element/templates/package.json
@@ -29,7 +29,7 @@
   "module": "<%= elementName %>.js",
   "umd": "<%= elementName %>.umd.js",
   "scripts": {
-    "test": "../../node_modules/.bin/wct --configFile ../../wct.conf.json node_modules/<%= orgNpm %>/<%= elementName %>/test/",
+    "test": "wct --configFile ../../wct.conf.json node_modules/<%= orgNpm %>/<%= elementName %>/test/",
     <%- libraryScripts %>
   },
   "author": {

--- a/packages/generator-wcfactory/generators/factory/templates/themes/default-theme/package.json
+++ b/packages/generator-wcfactory/generators/factory/templates/themes/default-theme/package.json
@@ -2,7 +2,7 @@
   "name": "<%= orgNpm %>/default-theme",
   "description": "<%= name %> theme placeholder",
   "scripts": {
-    "test": "../../node_modules/.bin/wct --configFile ../../wct.conf.json elements/all/test/"
+    "test": "wct --configFile ../../wct.conf.json elements/all/test/"
   },
   "version": "0.0.1",
   "private": true,

--- a/packages/generator-wcfactory/generators/start/templates/templates/libraries/HAXcmsTheme/package.json
+++ b/packages/generator-wcfactory/generators/start/templates/templates/libraries/HAXcmsTheme/package.json
@@ -13,11 +13,11 @@
   "version": "0.0.1",
   "scripts": {
     "start": "yarn run dev",
-    "build": "../../node_modules/.bin/gulp --gulpfile=gulpfile.cjs && ../../node_modules/.bin/rollup -c && ../../node_modules/.bin/prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
-    "dev": "../../node_modules/.bin/concurrently --kill-others \"yarn run watch\" \"yarn run serve\"",
-    "watch": "../../node_modules/.bin/gulp dev --gulpfile=gulpfile.cjs",
-    "serve": "../../node_modules/.bin/es-dev-server -c ../../es-dev-server.config.js",
-    "lighthouse": "../../node_modules/.bin/gulp lighthouse --gulpfile=gulpfile.cjs"
+    "build": "gulp --gulpfile=gulpfile.cjs && rollup -c && prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
+    "dev": "concurrently --kill-others \"yarn run watch\" \"yarn run serve\"",
+    "watch": "gulp dev --gulpfile=gulpfile.cjs",
+    "serve": "es-dev-server -c ../../es-dev-server.config.js",
+    "lighthouse": "gulp lighthouse --gulpfile=gulpfile.cjs"
   },
   "dependencies": {
     "lit-element": "^2.3.1",

--- a/packages/generator-wcfactory/generators/start/templates/templates/libraries/HTMLElement/package.json
+++ b/packages/generator-wcfactory/generators/start/templates/templates/libraries/HTMLElement/package.json
@@ -10,11 +10,11 @@
   "version": "0.0.1",
   "scripts": {
     "start": "yarn run dev",
-    "build": "../../node_modules/.bin/gulp --gulpfile=gulpfile.cjs && ../../node_modules/.bin/rollup -c && ../../node_modules/.bin/prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
-    "dev": "../../node_modules/.bin/concurrently --kill-others \"yarn run watch\" \"yarn run serve\"",
-    "watch": "../../node_modules/.bin/gulp dev --gulpfile=gulpfile.cjs",
-    "serve": "../../node_modules/.bin/es-dev-server -c ../../es-dev-server.config.js",
-    "lighthouse": "../../node_modules/.bin/gulp lighthouse --gulpfile=gulpfile.cjs"
+    "build": "gulp --gulpfile=gulpfile.cjs && rollup -c && prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
+    "dev": "concurrently --kill-others \"yarn run watch\" \"yarn run serve\"",
+    "watch": "gulp dev --gulpfile=gulpfile.cjs",
+    "serve": "es-dev-server -c ../../es-dev-server.config.js",
+    "lighthouse": "gulp lighthouse --gulpfile=gulpfile.cjs"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/generator-wcfactory/generators/start/templates/templates/libraries/LitElement/package.json
+++ b/packages/generator-wcfactory/generators/start/templates/templates/libraries/LitElement/package.json
@@ -13,11 +13,11 @@
   "version": "0.0.1",
   "scripts": {
     "start": "yarn run dev",
-    "build": "../../node_modules/.bin/gulp --gulpfile=gulpfile.cjs && ../../node_modules/.bin/rollup -c && ../../node_modules/.bin/prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
-    "dev": "../../node_modules/.bin/concurrently --kill-others \"yarn run watch\" \"yarn run serve\"",
-    "watch": "../../node_modules/.bin/gulp dev --gulpfile=gulpfile.cjs",
-    "serve": "../../node_modules/.bin/es-dev-server -c ../../es-dev-server.config.js",
-    "lighthouse": "../../node_modules/.bin/gulp lighthouse --gulpfile=gulpfile.cjs"
+    "build": "gulp --gulpfile=gulpfile.cjs && rollup -c && prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
+    "dev": "concurrently --kill-others \"yarn run watch\" \"yarn run serve\"",
+    "watch": "gulp dev --gulpfile=gulpfile.cjs",
+    "serve": "es-dev-server -c ../../es-dev-server.config.js",
+    "lighthouse": "gulp lighthouse --gulpfile=gulpfile.cjs"
   },
   "dependencies": {
     "lit-element": "^2.3.1"

--- a/packages/generator-wcfactory/generators/start/templates/templates/libraries/SingletonElement/package.json
+++ b/packages/generator-wcfactory/generators/start/templates/templates/libraries/SingletonElement/package.json
@@ -13,11 +13,11 @@
   "version": "0.0.1",
   "scripts": {
     "start": "yarn run dev",
-    "build": "../../node_modules/.bin/gulp --gulpfile=gulpfile.cjs && ../../node_modules/.bin/rollup -c && ../../node_modules/.bin/prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
-    "dev": "../../node_modules/.bin/concurrently --kill-others \"yarn run watch\" \"yarn run serve\"",
-    "watch": "../../node_modules/.bin/gulp dev --gulpfile=gulpfile.cjs",
-    "serve": "../../node_modules/.bin/es-dev-server -c ../../es-dev-server.config.js",
-    "lighthouse": "../../node_modules/.bin/gulp lighthouse --gulpfile=gulpfile.cjs"
+    "build": "gulp --gulpfile=gulpfile.cjs && rollup -c && prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
+    "dev": "concurrently --kill-others \"yarn run watch\" \"yarn run serve\"",
+    "watch": "gulp dev --gulpfile=gulpfile.cjs",
+    "serve": "es-dev-server -c ../../es-dev-server.config.js",
+    "lighthouse": "gulp lighthouse --gulpfile=gulpfile.cjs"
   },
   "dependencies": {
     "lit-element": "^2.3.1"

--- a/packages/generator-wcfactory/tests/heym-asdf/package.json
+++ b/packages/generator-wcfactory/tests/heym-asdf/package.json
@@ -15,12 +15,12 @@
   "es2015": "heym-asdf.js",
   "amd": "heym-asdf.amd.js",
   "scripts": {
-    "build": "../../node_modules/.bin/gulp --gulpfile=gulpfile.cjs && ../../node_modules/.bin/rollup -c && ../../node_modules/.bin/prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
+    "build": "gulp --gulpfile=gulpfile.cjs && rollup -c && prettier --ignore-path ../../.prettierignore --write '**/*.{js,json}' && wca analyze \"**/*.js\" --outFile custom-elements.json",
     "dev": "npm run build && open ./src && concurrently --kill-others \"npm run watch\" \"npm run serve\"",
-    "watch": "../../node_modules/.bin/gulp dev --gulpfile=gulpfile.cjs",
+    "watch": "gulp dev --gulpfile=gulpfile.cjs",
     "serve": "cd build/es6 && polymer serve --npm --module-resolution=node --open",
-    "test": "../../node_modules/.bin/wct --configFile ../../wct.conf.json node_modules/@rhelements/heym-asdf/test/",
-    "lighthouse": "../../node_modules/.bin/gulp lighthouse --gulpfile=gulpfile.cjs"
+    "test": "wct --configFile ../../wct.conf.json node_modules/@rhelements/heym-asdf/test/",
+    "lighthouse": "gulp lighthouse --gulpfile=gulpfile.cjs"
   },
   "author": {
     "name": "heymp"


### PR DESCRIPTION
node will automically walk up the file tree looking for node_modules/.bin folders and checking if a given bin is located in that folder.

Caveat: the scan prefers the folder closest to where the script is being called. If a local folder has a version of `wtc` that differs from the project wide one, the local (package specific one) would take precedence.