### PR TITLE
Update README with http-server dependency for wcf ui command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ $ yarn global add @wcfactory/cli
 $ yarn global add polymer-cli
 $ yarn global add lerna
 $ yarn global add web-component-analyzer
+$ yarn global add http-server
 ```
 
 ## Windows


### PR DESCRIPTION
`wcf ui` command requires `http-server` as a global dependency, so I added this to the readme.